### PR TITLE
refactor: Highlighting/Editor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,8 +7,7 @@
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "6.41.0",
-        "@vedivad/codemirror-typst": "^0.9.1",
-        "@vedivad/typst-web-service": "^0.9.1",
+        "@vedivad/codemirror-typst": "^0.11.0",
         "codemirror": "^6.0.2",
         "marked": "^18.0.2",
         "marked-alert": "^2.1.2",
@@ -209,9 +208,9 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@vedivad/codemirror-typst": ["@vedivad/codemirror-typst@0.9.1", "", { "dependencies": { "@vedivad/typst-web-service": "^0.9.1", "codemirror-shiki": "^0.3.0", "markdown-it": "^14.1.1", "shiki": "^4" }, "peerDependencies": { "@codemirror/autocomplete": "^6", "@codemirror/lint": "^6", "@codemirror/state": "^6", "@codemirror/view": "^6" } }, "sha512-p/EKfWpiw+CDVaIU9IvEJEzdj0mNVI0pMF9wRhyZCETgY7mqDbkQ4Dwsc9vKFfaDRuRcOhXo84iNv60DK6seSg=="],
+    "@vedivad/codemirror-typst": ["@vedivad/codemirror-typst@0.11.0", "", { "dependencies": { "@vedivad/typst-web-service": "^0.11.0", "codemirror-shiki": "^0.3.0", "markdown-it": "^14.1.1", "shiki": "^4" }, "peerDependencies": { "@codemirror/autocomplete": "^6", "@codemirror/lint": "^6", "@codemirror/state": "^6", "@codemirror/view": "^6" } }, "sha512-M4nfETjEyLgfUyJ/86JtvAMPaBklZsZt2wJXk0iQ1+/f1HAfe2XmwTRO51vmjuImKhuPCemUnIgmE9S6ix2PWw=="],
 
-    "@vedivad/typst-web-service": ["@vedivad/typst-web-service@0.9.1", "", { "dependencies": { "@myriaddreamin/typst-ts-renderer": "^0.7.0-rc2", "@myriaddreamin/typst-ts-web-compiler": "^0.7.0-rc2", "@myriaddreamin/typst.ts": "^0.7.0-rc2", "@typstyle/typstyle-wasm-bundler": "^0.14.4", "comlink": "^4.4.2", "tinymist-web": "https://github.com/Myriad-Dreamin/tinymist/releases/download/v0.14.10/tinymist-web.tar.gz" } }, "sha512-mP58z5oGnRBXa3hCO/pptuM3yTf2B9BYVYo89/4vo92fGaBMhXodpik4XUP9agfl7qRYwykE8dOFy86qODV9KA=="],
+    "@vedivad/typst-web-service": ["@vedivad/typst-web-service@0.11.0", "", { "dependencies": { "@myriaddreamin/typst-ts-renderer": "^0.7.0-rc2", "@myriaddreamin/typst-ts-web-compiler": "^0.7.0-rc2", "@myriaddreamin/typst.ts": "^0.7.0-rc2", "@typstyle/typstyle-wasm-bundler": "^0.14.4", "comlink": "^4.4.2", "tinymist-web": "https://github.com/Myriad-Dreamin/tinymist/releases/download/v0.14.10/tinymist-web.tar.gz" } }, "sha512-IeY1TyKGU8pHTSjjCqV7hrk45bZrgRxz5/KIoexZ4NYzbrm6gMhWoVh9WJ3iTNTpS7jTDmK75uAepczyitbQlQ=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   "dependencies": {
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "6.41.0",
-    "@vedivad/codemirror-typst": "^0.9.1",
-    "@vedivad/typst-web-service": "^0.9.1",
+    "@vedivad/codemirror-typst": "^0.11.0",
     "codemirror": "^6.0.2",
     "marked": "^18.0.2",
     "marked-alert": "^2.1.2",

--- a/src/editor/Editor.svelte
+++ b/src/editor/Editor.svelte
@@ -82,7 +82,7 @@
   }
 
   let cancelled = false;
-  let unsub: (() => void) | undefined;
+  let unsubscribe: (() => void) | undefined;
 
   onMount(async () => {
     for (const step of [
@@ -98,7 +98,7 @@
     // Subscribe after compile() — onCompile synchronously replays the cached
     // result, so this hands us the fresh render without flashing the previous
     // chapter's pages, and still catches future autoCompiles from edits.
-    unsub = project.onCompile((result) => {
+    unsubscribe = project.onCompile((result) => {
       if (result.vector) {
         void renderer
           .renderSvgPages(result.vector)
@@ -110,7 +110,7 @@
 
   onDestroy(() => {
     cancelled = true;
-    unsub?.();
+    unsubscribe?.();
     view?.destroy();
   });
 

--- a/src/editor/Editor.svelte
+++ b/src/editor/Editor.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
   import { EditorView, basicSetup } from "codemirror";
-  import { EditorState, Compartment, Transaction } from "@codemirror/state";
+  import { EditorState } from "@codemirror/state";
   import { keymap } from "@codemirror/view";
   import { indentWithTab } from "@codemirror/commands";
   import diagnosticCopyPlugin from "./diagnosticCopyPlugin";
   import {
-    createTypstExtensions,
-    createTypstShikiHighlighting,
+    createTypstHighlighting,
+    createTypstSetup,
+    typstFilePath,
     TypstCompiler,
     TypstProject,
     TypstRenderer,
     TypstFormatter,
   } from "@vedivad/codemirror-typst";
-  import type { TypstShikiHighlighting } from "@vedivad/codemirror-typst";
+  import type { TypstHighlightingController } from "@vedivad/codemirror-typst";
 
   interface Props {
     doc?: string;
@@ -44,13 +45,11 @@
   let solutionScrollTop = 0;
   let effectGeneration = 0;
 
-  const highlightCompartment = new Compartment();
-
-  let shikiHighlighting: TypstShikiHighlighting | undefined;
-  // index 0 of createTypstExtensions is the built-in shiki, we replace it with our compartment
-  let compilerExtensions: Awaited<ReturnType<typeof createTypstExtensions>> | undefined;
+  let highlighting: TypstHighlightingController | undefined;
+  let typstExtensions: ReturnType<typeof createTypstSetup> | undefined;
   let formatter: TypstFormatter | undefined;
   let project: TypstProject | undefined;
+  const mainPath = "/main.typ";
 
   async function init() {
     const renderer = TypstRenderer.create();
@@ -59,15 +58,19 @@
     // Compiler WASM load and Shiki language pack are independent — run in parallel
     const [compiler, shiki] = await Promise.all([
       TypstCompiler.create(),
-      createTypstShikiHighlighting({
+      createTypstHighlighting({
         themes: { light: "github-light", dark: "github-dark-dimmed" },
-        defaultColor: theme,
+        theme,
       }),
     ]);
 
-    shikiHighlighting = shiki;
-    project = new TypstProject({ compiler, autoCompile: { debounceMs: 50, maxWaitMs: 300 } });
-    project.onCompile((result) => {
+    highlighting = shiki;
+    const typstProject = new TypstProject({
+      compiler,
+      autoCompile: { debounceMs: 50, maxWaitMs: 300 },
+    });
+    project = typstProject;
+    typstProject.onCompile((result) => {
       if (result.vector) {
         void renderer
           .renderSvgPages(result.vector)
@@ -75,11 +78,12 @@
       }
     });
 
-    const typstExtension = await createTypstExtensions({
-      project,
-      highlighting: { theme: "light" },
+    typstExtensions = createTypstSetup({
+      project: typstProject,
+      sync: "editor-driven",
+      highlighting: shiki,
+      formatter: { instance: formatter },
     });
-    compilerExtensions = typstExtension.slice(1);
   }
 
   const ready = init();
@@ -92,7 +96,7 @@
   /** Build a fresh CodeMirror view for the given document and trigger an initial compile. */
   function createView(initialDoc: string) {
     view?.destroy();
-    if (!shikiHighlighting || !compilerExtensions) {
+    if (!highlighting || !typstExtensions) {
       return;
     }
 
@@ -109,25 +113,17 @@
             { key: "F2", run: () => true },
           ]),
           basicSetup,
-          highlightCompartment.of(shikiHighlighting.getTheme(theme)),
           EditorView.updateListener.of((u) => {
             if (u.docChanged) {
               onchange?.(u.state.doc.toString());
             }
           }),
-          ...compilerExtensions,
+          ...typstExtensions,
+          typstFilePath.of(mainPath),
           diagnosticCopyPlugin,
         ],
       }),
     });
-
-    // Trigger initial compile, replace doc with itself so compiler sees docChanged
-    if (initialDoc.length > 0) {
-      view.dispatch({
-        changes: fullDocChange(view, initialDoc),
-        annotations: Transaction.addToHistory.of(false),
-      });
-    }
   }
 
   $effect(() => {
@@ -145,7 +141,8 @@
       // Skip if a newer effect has already fired (e.g. user switched chapters while init was pending)
       if (gen !== effectGeneration) return;
       await project?.clear();
-      if (Object.keys(files).length > 0) await project?.setMany(files);
+      await project?.setMany({ ...files, [mainPath]: initialDoc });
+      await project?.compile();
       createView(initialDoc);
     });
 
@@ -153,13 +150,8 @@
   });
 
   $effect(() => {
-    if (view && shikiHighlighting) {
-      // Reconfigure compartment + force docChanged so Shiki re-decorates existing tokens
-      view.dispatch({
-        effects: highlightCompartment.reconfigure(shikiHighlighting.getTheme(theme)),
-        changes: fullDocChange(view, view.state.doc.toString()),
-        annotations: Transaction.addToHistory.of(false),
-      });
+    if (view && highlighting) {
+      highlighting.setTheme(view, theme);
     }
   });
 

--- a/src/editor/Editor.svelte
+++ b/src/editor/Editor.svelte
@@ -1,24 +1,16 @@
 <script lang="ts">
+  import { onDestroy, onMount } from "svelte";
   import { EditorView, basicSetup } from "codemirror";
   import { EditorState } from "@codemirror/state";
   import { keymap } from "@codemirror/view";
   import { indentWithTab } from "@codemirror/commands";
   import diagnosticCopyPlugin from "./diagnosticCopyPlugin";
-  import {
-    createTypstHighlighting,
-    createTypstSetup,
-    typstFilePath,
-    TypstCompiler,
-    TypstProject,
-    TypstRenderer,
-    TypstFormatter,
-  } from "@vedivad/codemirror-typst";
-  import type { TypstHighlightingController } from "@vedivad/codemirror-typst";
+  import { createTypstSetup, typstFilePath } from "@vedivad/codemirror-typst";
+  import { useTypstResources } from "./typst-resources";
 
   interface Props {
     doc?: string;
     template?: string;
-    docKey?: string;
     solution?: string;
     auxFiles?: Record<string, string>;
     theme?: "light" | "dark";
@@ -29,7 +21,6 @@
   let {
     doc = "",
     template = "",
-    docKey = "",
     solution,
     auxFiles = {},
     theme = "light",
@@ -37,70 +28,27 @@
     oncompile,
   }: Props = $props();
 
+  const { project, highlighting, formatter, renderer } = useTypstResources();
+  const mainPath = "/main.typ";
+
   let editorContainer: HTMLDivElement;
   let view: EditorView | undefined = $state();
   let showingSolution = $state(false);
   let savedCode: string | undefined;
   let userScrollTop = 0;
   let solutionScrollTop = 0;
-  let effectGeneration = 0;
 
-  let highlighting: TypstHighlightingController | undefined;
-  let typstExtensions: ReturnType<typeof createTypstSetup> | undefined;
-  let formatter: TypstFormatter | undefined;
-  let project: TypstProject | undefined;
-  const mainPath = "/main.typ";
+  const typstExtensions = createTypstSetup({
+    project,
+    sync: "editor-driven",
+    highlighting,
+    formatter: { instance: formatter },
+  });
 
-  async function init() {
-    const renderer = TypstRenderer.create();
-    formatter = TypstFormatter.create({ max_width: 80, wrap_text: true });
-
-    // Compiler WASM load and Shiki language pack are independent — run in parallel
-    const [compiler, shiki] = await Promise.all([
-      TypstCompiler.create(),
-      createTypstHighlighting({
-        themes: { light: "github-light", dark: "github-dark-dimmed" },
-        theme,
-      }),
-    ]);
-
-    highlighting = shiki;
-    const typstProject = new TypstProject({
-      compiler,
-      autoCompile: { debounceMs: 50, maxWaitMs: 300 },
-    });
-    project = typstProject;
-    typstProject.onCompile((result) => {
-      if (result.vector) {
-        void renderer
-          .renderSvgPages(result.vector)
-          .then((pages) => oncompile?.(pages.map((p) => p.svg)));
-      }
-    });
-
-    typstExtensions = createTypstSetup({
-      project: typstProject,
-      sync: "editor-driven",
-      highlighting: shiki,
-      formatter: { instance: formatter },
-    });
-  }
-
-  const ready = init();
-
-  /** Returns a CodeMirror ChangeSpec that replaces the entire document. */
-  function fullDocChange(v: EditorView, content: string) {
-    return { from: 0, to: v.state.doc.length, insert: content };
-  }
-
-  /** Build a fresh CodeMirror view for the given document and trigger an initial compile. */
-  function createView(initialDoc: string) {
+  /** Build a fresh CodeMirror view for the given document. */
+  function createView(initialDoc: string, initialScrollTop = 0) {
     view?.destroy();
-    if (!highlighting || !typstExtensions) {
-      return;
-    }
-
-    view = new EditorView({
+    const v = new EditorView({
       parent: editorContainer,
       state: EditorState.create({
         doc: initialDoc,
@@ -124,33 +72,50 @@
         ],
       }),
     });
+    view = v;
+
+    if (initialScrollTop > 0) {
+      requestAnimationFrame(() => {
+        v.scrollDOM.scrollTop = initialScrollTop;
+      });
+    }
   }
 
-  $effect(() => {
-    // Destructure to read doc, docKey, and auxFiles synchronously so Svelte tracks all three.
-    // docKey ensures the effect re-runs on chapter/locale change even if doc content is identical.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [initialDoc, _key, files] = [doc, docKey, auxFiles];
-    const gen = ++effectGeneration;
-    showingSolution = false;
-    savedCode = undefined;
-    // Clear container immediately so stale content from previous chapter is never visible
-    // eslint-disable-next-line svelte/no-dom-manipulating, @typescript-eslint/no-unnecessary-condition
-    editorContainer?.replaceChildren();
-    void ready.then(async () => {
-      // Skip if a newer effect has already fired (e.g. user switched chapters while init was pending)
-      if (gen !== effectGeneration) return;
-      await project?.clear();
-      await project?.setMany({ ...files, [mainPath]: initialDoc });
-      await project?.compile();
-      createView(initialDoc);
-    });
+  let cancelled = false;
+  let unsub: (() => void) | undefined;
 
-    return () => view?.destroy();
+  onMount(async () => {
+    for (const step of [
+      () => project.clear(),
+      () => project.setMany({ ...auxFiles, [mainPath]: doc }),
+      () => project.compile(),
+    ]) {
+      if (cancelled) return;
+      await step();
+    }
+    if (cancelled) return;
+
+    // Subscribe after compile() — onCompile synchronously replays the cached
+    // result, so this hands us the fresh render without flashing the previous
+    // chapter's pages, and still catches future autoCompiles from edits.
+    unsub = project.onCompile((result) => {
+      if (result.vector) {
+        void renderer
+          .renderSvgPages(result.vector)
+          .then((pages) => oncompile?.(pages.map((p) => p.svg)));
+      }
+    });
+    createView(doc);
+  });
+
+  onDestroy(() => {
+    cancelled = true;
+    unsub?.();
+    view?.destroy();
   });
 
   $effect(() => {
-    if (view && highlighting) {
+    if (view) {
       highlighting.setTheme(view, theme);
     }
   });
@@ -165,15 +130,13 @@
 
   /** Format the current document with the Typst formatter and apply changes if different. */
   async function format() {
-    if (!view || !formatter) {
-      return;
-    }
+    if (!view) return;
 
     const source = view.state.doc.toString();
     const formatted = await formatter.format(source);
 
     if (formatted !== source) {
-      view.dispatch({ changes: fullDocChange(view, formatted) });
+      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: formatted } });
     }
   }
 
@@ -186,21 +149,13 @@
     if (showingSolution) {
       solutionScrollTop = view?.scrollDOM.scrollTop ?? 0;
       showingSolution = false;
-      createView(savedCode ?? doc);
+      createView(savedCode ?? doc, userScrollTop);
       savedCode = undefined;
     } else {
       userScrollTop = view?.scrollDOM.scrollTop ?? 0;
       savedCode = view?.state.doc.toString();
       showingSolution = true;
-      createView(solution);
-    }
-
-    const restoreTop = showingSolution ? solutionScrollTop : userScrollTop;
-    if (view) {
-      const v = view;
-      requestAnimationFrame(() => {
-        v.scrollDOM.scrollTop = restoreTop;
-      });
+      createView(solution, solutionScrollTop);
     }
   }
 </script>

--- a/src/editor/EditorShell.svelte
+++ b/src/editor/EditorShell.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { onMount, type Snippet } from "svelte";
+  import {
+    createTypstHighlighting,
+    TypstCompiler,
+    TypstProject,
+    TypstRenderer,
+    TypstFormatter,
+  } from "@vedivad/codemirror-typst";
+  import { provideTypstResources } from "./typst-resources";
+
+  interface Props {
+    theme: "light" | "dark";
+    children: Snippet;
+  }
+
+  let { theme, children }: Props = $props();
+
+  const container = provideTypstResources();
+  let ready = $state(false);
+
+  onMount(async () => {
+    const renderer = TypstRenderer.create();
+    const formatter = TypstFormatter.create({ max_width: 80, wrap_text: true });
+    const [compiler, highlighting] = await Promise.all([
+      TypstCompiler.create(),
+      createTypstHighlighting({
+        themes: { light: "github-light", dark: "github-dark-dimmed" },
+        theme,
+      }),
+    ]);
+    const project = new TypstProject({
+      compiler,
+      autoCompile: { debounceMs: 50, maxWaitMs: 300 },
+    });
+    container.current = { project, highlighting, formatter, renderer };
+    ready = true;
+  });
+</script>
+
+{#if ready}
+  {@render children()}
+{/if}

--- a/src/editor/Workspace.svelte
+++ b/src/editor/Workspace.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Editor from "./Editor.svelte";
+  import EditorShell from "./EditorShell.svelte";
   import Preview from "./Preview.svelte";
   import ResizeHandle from "../components/ResizeHandle.svelte";
   import { getChapterTemplate, getChapterSolution, getChapterAuxFiles } from "../content";
@@ -61,16 +62,19 @@
 
 <div class="workspace">
   <div class="pane" style="flex: {editorFraction}">
-    <Editor
-      {doc}
-      {template}
-      {solution}
-      {auxFiles}
-      {theme}
-      docKey="{locale}:{chapterKey}"
-      onchange={handleChange}
-      oncompile={(p: string[]) => (pages = p)}
-    />
+    <EditorShell {theme}>
+      {#key `${locale}:${chapterKey}`}
+        <Editor
+          {doc}
+          {template}
+          {solution}
+          {auxFiles}
+          {theme}
+          onchange={handleChange}
+          oncompile={(p: string[]) => (pages = p)}
+        />
+      {/key}
+    </EditorShell>
   </div>
 
   <ResizeHandle

--- a/src/editor/typst-resources.ts
+++ b/src/editor/typst-resources.ts
@@ -1,0 +1,34 @@
+import { getContext, setContext } from "svelte";
+import type {
+  TypstProject,
+  TypstFormatter,
+  TypstRenderer,
+  TypstHighlightingController,
+} from "@vedivad/codemirror-typst";
+
+export interface TypstResources {
+  project: TypstProject;
+  highlighting: TypstHighlightingController;
+  formatter: TypstFormatter;
+  renderer: TypstRenderer;
+}
+
+interface Container {
+  current: TypstResources | undefined;
+}
+
+const KEY = Symbol("typst-resources");
+
+export function provideTypstResources(): Container {
+  const container: Container = { current: undefined };
+  setContext(KEY, container);
+  return container;
+}
+
+export function useTypstResources(): TypstResources {
+  const container = getContext<Container | undefined>(KEY);
+  if (!container?.current) {
+    throw new Error("useTypstResources called outside <EditorShell> or before resources are ready");
+  }
+  return container.current;
+}


### PR DESCRIPTION
New update on typst-web project.
Also refactor the Editor and split into EditorShell (sets up typst env persistently) and Editor (render docs with said typst env).

Also gets rid of lint disable comments.